### PR TITLE
remove duplicate update m1 call

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1071,8 +1071,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 		if bc.chainConfig.XDPoS != nil && ((block.NumberU64() % bc.chainConfig.XDPoS.Epoch) == (bc.chainConfig.XDPoS.Epoch - bc.chainConfig.XDPoS.Gap)) {
 			err := bc.UpdateM1()
 			if err != nil {
-				log.Error("Error when update masternodes set. Stopping node", "err", err)
-				os.Exit(1)
+				log.Crit("Error when update masternodes set. Stopping node", "err", err)
 			}
 		}
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"math/big"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -620,14 +619,6 @@ func (w *worker) resultLoop() {
 				// epoch block
 				if (block.NumberU64() % w.config.XDPoS.Epoch) == 0 {
 					core.CheckpointCh <- 1
-				}
-				// prepare set of masternodes for the next epoch
-				if (block.NumberU64() % w.config.XDPoS.Epoch) == (w.config.XDPoS.Epoch - w.config.XDPoS.Gap) {
-					err := w.chain.UpdateM1()
-					if err != nil {
-						log.Error("Error when update masternodes set. Stopping node", "err", err)
-						os.Exit(1)
-					}
 				}
 			}
 			w.chain.PostChainEvents(events, logs)


### PR DESCRIPTION
resultLoop function also calls `WriteBlockWithState` which contains the logic of updatem1 trigger.