### PR TITLE
xin-144 avoid duplicate messages

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -831,7 +831,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 		// Mark the peer as owning the vote and process it
-		p = pm.peers.Peer(p.id) // because sender and receive peer are different
+		// because peer has 2 address sender and receive, so use p.id to find the right address
+		p = pm.peers.Peer(p.id)
 		p.MarkVote(vote.Hash())
 		pm.bft.Vote(&vote)
 	case msg.Code == TimeoutMsg:
@@ -841,7 +842,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 		// Mark the peer as owning the timeout and process it
-		p = pm.peers.Peer(p.id) // because sender and receive peer are different
+		// because peer has 2 address sender and receive, so use p.id to find the right address
+		p = pm.peers.Peer(p.id)
 		p.MarkTimeout(timeout.Hash())
 		pm.bft.Timeout(&timeout)
 	case msg.Code == SyncInfoMsg:
@@ -850,7 +852,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 		// Mark the peer as owning the syncInfo and process it
-		p = pm.peers.Peer(p.id) // because sender and receive peer are different
+		// because peer has 2 address sender and receive, so use p.id to find the right address
+		p = pm.peers.Peer(p.id)
 		p.MarkSyncInfo(syncInfo.Hash())
 		pm.bft.SyncInfo(&syncInfo)
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -831,6 +831,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 		// Mark the peer as owning the vote and process it
+		p = pm.peers.Peer(p.id) // because sender and receive peer are different
 		p.MarkVote(vote.Hash())
 		pm.bft.Vote(&vote)
 	case msg.Code == TimeoutMsg:
@@ -840,6 +841,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 		// Mark the peer as owning the timeout and process it
+		p = pm.peers.Peer(p.id) // because sender and receive peer are different
 		p.MarkTimeout(timeout.Hash())
 		pm.bft.Timeout(&timeout)
 	case msg.Code == SyncInfoMsg:
@@ -848,6 +850,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 		// Mark the peer as owning the syncInfo and process it
+		p = pm.peers.Peer(p.id) // because sender and receive peer are different
 		p.MarkSyncInfo(syncInfo.Hash())
 		pm.bft.SyncInfo(&syncInfo)
 


### PR DESCRIPTION
This is existed behaviour on original code. Not sure this is intension or some bug, so create another ticket. 
New Issue ticket: xin-158
Some behaviour discovered, every new node peer to other nodes, it would register twice, one for sending message one for receiving. So that we see duplicate messages send and received. But maybe this is expected design from ethereum.  
