### PR TITLE
xin-190 bug fix for snapshot failed to load from db

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -582,6 +582,7 @@ func (x *XDPoS_v2) VerifyVoteMessage(chain consensus.ChainReader, vote *utils.Vo
 	snapshot, err := x.getSnapshot(chain, vote.GapNumber, true)
 	if err != nil {
 		log.Error("[VerifyVoteMessage] fail to get snapshot for a vote message", "BlockNum", vote.ProposedBlockInfo.Number, "Hash", vote.ProposedBlockInfo.Hash, "Error", err.Error())
+		return false, err
 	}
 	verified, _, err := x.verifyMsgSignature(utils.VoteSigHash(&utils.VoteForSign{
 		ProposedBlockInfo: vote.ProposedBlockInfo,


### PR DESCRIPTION
Error Msg from devnet, improve the error handle on this case
```
ERROR[05-18|08:40:51] Cannot find snapshot from last gap block err="leveldb: not found" number=7417350 hash=1dcc4d…d49347
ERROR[05-18|08:40:51] [VerifyVoteMessage] fail to get snapshot for a vote message BlockNum=7418553 Hash=6a5051…20f1a2
             Error="leveldb: not found"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x964a2d]

goroutine 55294 [running]:
github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2.(*XDPoS_v2).VerifyVoteMessage(0xc00065e5a0, 0x1719ac0, 0xc0009a6000, 0xc038054c60, 0xe30b00, 0x1e3b2d0, 0x1fb51c0)
        /work/XDPoSChain/consensus/XDPoS/engines/engine_v2/engine.go:593 +0x15d
github.com/XinFinOrg/XDPoSChain/eth/bft.(*Bfter).Vote(0xc0001351f0, 0xc038054c60, 0x1fb14c1, 0x429d05bfab960000)
        /work/XDPoSChain/eth/bft/bft_handler.go:68 +0x2f1
created by github.com/XinFinOrg/XDPoSChain/eth.(*ProtocolManager).handleMsg
        /work/XDPoSChain/eth/handler.go:853 +0x280e
runtime: note: your Linux kernel may be buggy
runtime: note: see https://golang.org/wiki/LinuxKernelSignalVectorBug
runtime: note: mlock workaround for kernel bug failed with errno 12
```
