### PR TITLE
add initial function during load latest block from db

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -124,6 +124,15 @@ func NewFaker(db ethdb.Database, chainConfig *params.ChainConfig) *XDPoS {
 	return fakeEngine
 }
 
+func (x *XDPoS) Initial(chain consensus.ChainReader, header *types.Header) error {
+	switch x.config.BlockConsensusVersion(header.Number) {
+	case params.ConsensusEngineVersion2:
+		return x.EngineV2.Initial(chain, header)
+	default: // Default "v1"
+		return nil
+	}
+}
+
 /*
 	Eth Consensus engine interface implementation
 */

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -352,6 +352,13 @@ func (bc *BlockChain) loadLastState() error {
 	}
 	bc.hc.SetCurrentHeader(currentHeader)
 
+	if engine, ok := bc.Engine().(*XDPoS.XDPoS); ok {
+		err := engine.Initial(bc, currentHeader)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Restore the last known head fast block
 	bc.currentFastBlock.Store(currentBlock)
 	if head := GetHeadFastBlockHash(bc.db); head != (common.Hash{}) {


### PR DESCRIPTION
Miner node won't run initial function if miner is in penalty list
Error Message:
```
ERROR[05-17|06:19:32] [FindParentBlockToAssign] Can not find parent block from highestQC proposedBlockInfo x.highestQuorumCert.ProposedBlockInfo.Hash=000000…000000 x.highestQuorumCert.ProposedBlockInfo.Number=0

```
# New Behaviour
execute initial function after loading latest block from db