### PR TITLE
xin-201 skip message while synchronize

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -847,6 +847,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			pm.lendingpool.AddRemotes(txs)
 		}
 	case msg.Code == VoteMsg:
+		// VoteMsg arrived, make sure we have a valid and fresh chain to handle them
+		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+			break
+		}
+
 		var vote types.Vote
 		if err := msg.Decode(&vote); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -864,6 +869,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == TimeoutMsg:
+		// TimeoutMsg arrived, make sure we have a valid and fresh chain to handle them
+		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+			break
+		}
+
 		var timeout types.Timeout
 		if err := msg.Decode(&timeout); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -883,6 +893,11 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == SyncInfoMsg:
+		// SyncInfoMsg arrived, make sure we have a valid and fresh chain to handle them
+		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+			break
+		}
+
 		var syncInfo types.SyncInfo
 		if err := msg.Decode(&syncInfo); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)


### PR DESCRIPTION
```INFO [06-12|11:32:29] Imported new chain segment               blocks=450 txs=210 mgas=17.197 elapsed=427.348ms mgasps=40.240 number=58050   hash=a5971d…0fde2a                                                      cache=0.00B
ERROR[06-12|11:32:29] Cannot find snapshot from last gap block err="leveldb: not found" number=8017650 hash=1dcc4d…d49347
ERROR[06-12|11:32:29] [VerifyVoteMessage] fail to get snapshot for a vote message BlockNum=8019326 Hash=8757aa…9e7cdb
             Error="leveldb: not found"
ERROR[06-12|11:32:29] Verify BFT Vote                          error="leveldb: not found"
INFO [06-12|11:32:29] handler receive NewBlockMsg              Hash=0x8757aad981fe264985c698552ba38574f228edd7b131457a0325768edc9e7cdb Number=8019326
ERROR[06-12|11:32:29] Cannot find snapshot from last gap block err="leveldb: not found" number=8017650 hash=1dcc4d…d49347
ERROR[06-12|11:32:29] [VerifyVoteMessage] fail to get snapshot for a vote message BlockNum=8019326 Hash=8757aa…9e7cdb
             Error="leveldb: not found"```