### PR TITLE
xin-198 revert change peer address change

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -851,9 +851,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&vote); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		// Mark the peer as owning the vote and process it
-		// because peer has 2 address sender and receive, so use p.id to find the right address
-		p = pm.peers.Peer(p.id)
 		p.MarkVote(vote.Hash())
 
 		exist, _ := pm.knownVotes.ContainsOrAdd(vote.Hash(), true)
@@ -868,10 +865,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&timeout); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-
-		// Mark the peer as owning the timeout and process it
-		// because peer has 2 address sender and receive, so use p.id to find the right address
-		p = pm.peers.Peer(p.id)
 		p.MarkTimeout(timeout.Hash())
 
 		exist, _ := pm.knownTimeouts.ContainsOrAdd(timeout.Hash(), true)
@@ -887,9 +880,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&syncInfo); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		// Mark the peer as owning the syncInfo and process it
-		// because peer has 2 address sender and receive, so use p.id to find the right address
-		p = pm.peers.Peer(p.id)
 		p.MarkSyncInfo(syncInfo.Hash())
 
 		exist, _ := pm.knownSyncInfos.ContainsOrAdd(syncInfo.Hash(), true)


### PR DESCRIPTION
Revert the change of initial duplicate message transition prevention. Use the original design to avoid crash happens, doesn't want to add more lock or more code to increase the change of deadlock or bug 
Revert this PR: https://github.com/hash-laboratories-au/XDPoSChain/pull/68